### PR TITLE
Fixed building input variables for list of input objects

### DIFF
--- a/src/buildVariables.test.ts
+++ b/src/buildVariables.test.ts
@@ -202,6 +202,62 @@ describe(buildVariables.name, () => {
         },
       });
     });
+
+    it('returns correct variables for list of input objects', () => {
+      const params = {
+        data: {
+          name: 'Test club',
+          location: {
+            type: 'Point',
+            coordinates: [-34.6490871, -58.3457883],
+          },
+          extraFieldToIgnore: 'pipipi',
+          points: [
+            {
+              type: 'Point',
+              coordinates: [-34.6490871, -58.3457883],
+              extraFieldToIgnore: 'pipipi',
+            },
+            {
+              type: 'Point',
+              coordinates: [-42.6490871, -57.3457883],
+              extraFieldToIgnore: 'pipipi',
+            },
+          ],
+        },
+      };
+
+      const resource = getResourceByName('Club');
+
+      expect(
+        buildVariables(introspectionResult)(
+          resource,
+          CREATE,
+          params,
+          resource[CREATE],
+        ),
+      ).toEqual({
+        input: {
+          club: {
+            name: 'Test club',
+            location: {
+              type: 'Point',
+              coordinates: [-34.6490871, -58.3457883],
+            },
+            points: [
+              {
+                type: 'Point',
+                coordinates: [-34.6490871, -58.3457883],
+              },
+              {
+                type: 'Point',
+                coordinates: [-42.6490871, -57.3457883],
+              },
+            ],
+          },
+        },
+      });
+    });
   });
 
   describe(UPDATE, () => {

--- a/src/buildVariables.ts
+++ b/src/buildVariables.ts
@@ -364,6 +364,21 @@ const buildCleanObjectByQueryType =
           throw Error(`Expected an array at path '${curKey}'`);
         }
 
+        if (type?.kind === TypeKind.INPUT_OBJECT) {
+          const actualType = introspectionResults.types.find(
+            (t) => type.name === t.name && type.kind === t.kind,
+          ) as IntrospectionInputObjectType;
+          return {
+            ...acum,
+            [curKey]: curValue.map((item) =>
+              buildCleanObjectByQueryType(introspectionResults)(
+                item,
+                actualType.inputFields,
+              ),
+            ),
+          };
+        }
+
         return {
           ...acum,
           [curKey]: curValue.map((item) =>

--- a/src/test-introspection.ts
+++ b/src/test-introspection.ts
@@ -5295,6 +5295,28 @@ export const introspectionResult = {
           },
           defaultValue: null,
         },
+        {
+          __typename: '__InputValue',
+          name: 'points',
+          description: null,
+          type: {
+            __typename: '__Type',
+            kind: 'LIST',
+            name: null,
+            ofType: {
+              __typename: '__Type',
+              kind: 'NON_NULL',
+              name: null,
+              ofType: {
+                __typename: '__Type',
+                kind: 'INPUT_OBJECT',
+                name: 'PointInput',
+                ofType: null,
+              },
+            },
+          },
+          defaultValue: null,
+        },
       ],
       interfaces: null,
       enumValues: null,


### PR DESCRIPTION
When an input object has a field which itself is a list of input objects, the nested objects are not included in the built variables. The final variables contains only empty objects. This PR fixes the problem by loading the appropriate input object from introspection and using its fields in the building.

I also updated the testing introspection data to include a list of input objects in the CreateClubInput and added a test for this case.

Let me know if you need to update something in the PR since this seems to be the first one :)